### PR TITLE
fix(flows): FlowAppendView support for 'once' flag by forcing batch read

### DIFF
--- a/samples/bronze_sample/src/dataflows/feature_samples/dataflowspec/append_view_once_flow_main.json
+++ b/samples/bronze_sample/src/dataflows/feature_samples/dataflowspec/append_view_once_flow_main.json
@@ -1,0 +1,37 @@
+{
+    "dataFlowId": "append_view_once_flow",
+    "dataFlowGroup": "feature_samples_general",
+    "dataFlowType": "flow",
+    "targetFormat": "delta",
+    "targetDetails": {
+        "table": "append_view_once_flow",
+        "tableProperties": {
+            "delta.enableChangeDataFeed": "true"
+        }
+    },
+    "flowGroups": [
+        {
+            "flowGroupId": "main",
+            "flows": {
+                "f_customer_append_view_once_batch": {
+                    "flowType": "append_view",
+                    "flowDetails": {
+                        "targetTable": "append_view_once_flow",
+                        "sourceView": "v_append_view_once_flow",
+                        "once": true
+                    },
+                    "views": {
+                        "v_append_view_once_flow": {
+                            "mode": "batch",
+                            "sourceType": "delta",
+                            "sourceDetails": {
+                                "database": "{staging_schema}",
+                                "table": "customer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/samples/bronze_sample/src/dataflows/feature_samples/dataflowspec/append_view_once_flow_main.json
+++ b/samples/bronze_sample/src/dataflows/feature_samples/dataflowspec/append_view_once_flow_main.json
@@ -13,7 +13,7 @@
         {
             "flowGroupId": "main",
             "flows": {
-                "f_customer_append_view_once_batch": {
+                "f_customer_append_view_once": {
                     "flowType": "append_view",
                     "flowDetails": {
                         "targetTable": "append_view_once_flow",


### PR DESCRIPTION
Implementing a fix for appending views using the 'once' flag by ensuring the returned value is a batch DataFrame, not a streaming DataFrame.

As outlined in the [append_flow documentation](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow#parameters):
> Using once=True changes the flow: the return value must be a batch DataFrame in this case, not a streaming DataFrame.

Currently, configuring the 'once' flag with a batch data source fails with:
`View is not a streaming view and must be referenced using read.`

I've tested this fix manually, and it resolves the issue: it successfully appends a one-time batch flow into the target streaming table, as expected.