### PR TITLE
fix(docs): update docs and resolve build errors

### DIFF
--- a/docs/custom_markdown_builder.py
+++ b/docs/custom_markdown_builder.py
@@ -117,6 +117,8 @@ def setup(app):
     app.add_config_value('markdown_anchor_sections', True, 'env')
     app.add_config_value('markdown_docinfo', False, 'env')
     app.add_config_value('markdown_bullet', '*', 'env')
+    app.add_config_value('markdown_file_suffix', '.md', 'env')
+    app.add_config_value('markdown_flavor', 'github', 'env')
     app.add_builder(CustomMarkdownBuilder)
     return {
         'version': '0.1',

--- a/docs/source/build_pipeline_bundle_steps.rst
+++ b/docs/source/build_pipeline_bundle_steps.rst
@@ -116,11 +116,11 @@ The databricks.yml needs to be adjusted to include the following configurations:
       workspace:
         host: https://<workspace>.databricks.com/
       variables:
-        framework_source_path: /Workspace/Users/${var.owner}/.bundle/nab_dlt_framework/dev/files/src
+        framework_source_path: /Workspace/Users/${var.owner}/.bundle/lakeflow_framework/dev/current/files/src
 
 .. note::
     * The ``framework_source_path`` variable should point to the location of where the Lakeflow Framework bundle is deployed in the Databricks workspace. 
-    * By default the Lakeflow Framework Bundle is deployed to the owner's (person deploying the bundle) workspace files how folder under the ``.bundle/<project name>/<target environment>/files/`` directory.
+    * By default the Lakeflow Framework Bundle is deployed to the owner's (person deploying the bundle) workspace folder in the ``.bundle/<project name>/<target environment>/<framework_version>/files/src`` directory.
     * The ``owner`` can either be passed via the command line or via your CI/CD tool to allow deployment to the appropriate workspace files location in the given deployment context. See the :doc:`deploy_pipeline_bundle` section for more information.
 
 3. Select your Bundle Structure

--- a/docs/source/contributor_dev_docs.rst
+++ b/docs/source/contributor_dev_docs.rst
@@ -18,10 +18,13 @@ Writing Documentation
 --------------------------
 
 1. If a new feature is added or change to existing feature, ensure the feature is well documented in a new feature file or update the existing feature file with the name feature_<feature_name>.rst and add it to the :doc:`features` page.
+
    - In the feature file, include:
+
      - Feature description
      - Configuration options
      - Usage examples / sample code
+
 2. Update Data Flow Spec reference where applicable
 
 

--- a/docs/source/dataflow_spec_ref_cdc.rst
+++ b/docs/source/dataflow_spec_ref_cdc.rst
@@ -91,7 +91,7 @@ The ``cdcSnapshotSettings`` object contains the following properties:
      - ``string``
      - (*optional*) How to deduplicate source snapshot data before CDC. Default: ``off`` (no deduplication). Use ``full_row`` to deduplicate based on the full row (deterministic) excluding the ``_metadata`` column if present. Use ``keys_only`` to keep the first row per key(s): This is non-deterministic; as it preserves the first row per key(s) without ordering on any other columns.
 
-  .. warning::
+.. warning::
      The ``keys_only`` option is **non-deterministic**. It preserves the first row per key(s). Use it with caution and only when you accept that which duplicate row is kept may vary between runs.
 
 .. _cdc-apply-changes-from-snapshot-source:

--- a/docs/source/deploy_samples.rst
+++ b/docs/source/deploy_samples.rst
@@ -122,10 +122,10 @@ Single Command line deployment:
 4. Once deployment is complete, you can find the deployed bundles under ``/Users/<username>/.bundle/``
 
 Using the Samples
-----------------
+-----------------
 
 Test Data and Orchestrator
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Test Data and Orchestrator bundle includes:
 

--- a/docs/source/feature_materialized_views.rst
+++ b/docs/source/feature_materialized_views.rst
@@ -32,6 +32,7 @@ Key Features:
 
     To support Incremental refresh, some keywords and clauses require row-tracking to be enabled on the queried data sources.
     Refer to the the following links for details on:
+    
         - `Incremental Refresh <https://docs.databricks.com/aws/en/optimizations/incremental-refresh#support-for-materialized-view-incremental-refresh>`_
         - `Row Tracking <https://docs.databricks.com/aws/en/delta/row-tracking>`_
 

--- a/docs/source/feature_operational_metadata.rst
+++ b/docs/source/feature_operational_metadata.rst
@@ -72,7 +72,7 @@ The operational metadata configuration file must follow the schema below:
    * - **name**
      - The name of the operational metadata column.
    * - **type**
-     - The data_type of the column. For a list of valid data types please refer to the Databricks documentation: `https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html`_
+     - The data_type of the column. For a list of valid data types please refer to the Databricks `documentation <https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html>`__.
    * - **nullable**
      - A boolean that indicates whether the field can be null or not.
    * - **metadata**
@@ -94,7 +94,7 @@ The operational metadata configuration file must follow the schema below:
      - Payload
    * - **sql**
      - The column values will be derived by executing the SQL string provided in the payload.
-     - Any valid SQL function or expression, per the Databricks `SQL Language Reference <https://docs.databricks.com/en/sql/language-manual/index.html>`_.
+     - Any valid SQL function or expression, per the Databricks `SQL Language Reference <https://docs.databricks.com/en/sql/language-manual/index.html>`__.
    * - **pipeline_detail**
      - The name of any single ``pipeline_detail`` attribute.
      - The following attributes are available:
@@ -220,6 +220,7 @@ Use the ``features`` object to disable operational metadata at a dataflow spec l
    .. tab:: YAML
 
       .. code-block:: yaml
+
          :emphasize-lines: 4,5
 
          dataFlowId: feature_materialized_views
@@ -238,6 +239,7 @@ Use the ``configFlags`` array to disable operational metadata at a target table 
    .. tab:: JSON
 
       .. code-block:: json
+        
          :emphasize-lines: 24
 
         {
@@ -277,6 +279,7 @@ Use the ``configFlags`` array to disable operational metadata at a target table 
    .. tab:: YAML
 
       .. code-block:: yaml
+
          :emphasize-lines: 22,23
         
         dataFlowId: crm_1

--- a/docs/source/feature_python_dependency_management.rst
+++ b/docs/source/feature_python_dependency_management.rst
@@ -99,6 +99,7 @@ The recommended approach is to reference a ``requirements.txt`` file in your pip
 
 For example:
 .. code-block:: text
+  
    :caption: my_pipeline_bundle/requirements.txt
     requests>=2.28.0
     openpyxl

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,3 +8,4 @@ sphinx-copybutton
 sphinx_rtd_theme
 sphinx-design
 sphinxcontrib-spelling
+docutils<0.22


### PR DESCRIPTION
Updates the pipeline build documentation to better reflect naming migration to SDP and default Lakeflow Framework bundle deployment location. Along the way discovered doco building was failing for both HTML and md versions, so I've fixed those too (fixes #36).

There are a couple of notable points that probably need further thought;
- Docutils version pinning resolves a sphinx-tabs backrefs build error as described in [Issue#206](https://github.com/executablebooks/sphinx-tabs/issues/206). This is resolved by [PR#207](https://github.com/executablebooks/sphinx-tabs/pull/207) and released in [v3.5.0](https://github.com/executablebooks/sphinx-tabs/releases/tag/v3.5.0) however there is an incompatibility resolving dependencies with sphinx-toolbox  v4.1.2 which depends on sphinx-tabs>=1.2.1,<3.4.7. Ideally all reqs should have their versions pinned for consistency, however that's outside the scope of this PR.
- Additional config params bring the config up to date with sphinx-markdown-builder>=0.6.9 accounting for breaking changes introduced by [PR#40](https://github.com/liran-funaro/sphinx-markdown-builder/pull/40)
- The rest are resolutions to formatting issues throwing errors, however there are still a significant number of warnings (270+) that should probably be resolved. Notable among them are toctree orphans and duplicate labels.

The issues discovered also pretty strongly indicate that package pinning is a good idea, this will likely break again in future. Might also be a good idea to build the docs as part of a pass-required CI activity on PRs if the intention is to keep doco aligned with features.