### PR TITLE
fix: validate nodespec specs against the packaged schema at runtime

### DIFF
--- a/docs/source/build/spec-reference/nodespec.rst
+++ b/docs/source/build/spec-reference/nodespec.rst
@@ -134,7 +134,7 @@ view it reads; the target lists the transformation in its ``sources``:
 Editor autocomplete and validation
 ==================================
 
-Nodespec specs have a JSON Schema (``src/schemas/spec_nodespec.json``), so editors
+Nodespec specs have a JSON Schema (``src/lakeflow_framework/schemas/spec_nodespec.json``), so editors
 can offer key/value autocomplete and inline validation while you author them. The
 schema is wired through ``main.json``, which routes any ``*_main.json`` file to
 the correct spec schema based on its ``data_flow_type``. Add the ``json.schemas``

--- a/src/lakeflow_framework/constants.py
+++ b/src/lakeflow_framework/constants.py
@@ -67,6 +67,7 @@ class FrameworkPaths:
         LOGGER_CONFIG (str): Basename of the pluggable logger configuration file (under the resolved config root).
         MAIN_SPEC_SCHEMA_PATH (str): Path to the main specification schema file.
         FLOW_GROUP_SPEC_SCHEMA_PATH (str): Path to the flow group specification schema file.
+        NODESPEC_SPEC_SCHEMA_PATH (str): Path to the nodespec specification schema file.
         EXPECTATIONS_SPEC_SCHEMA_PATH (str): Path to the expectations specification schema file.
         SECRETS_SCHEMA_PATH (str): Path to the secrets specification schema file.
         TEMPLATE_DEFINITION_SPEC_SCHEMA_PATH (str): Path to the template definition specification schema file.
@@ -91,6 +92,7 @@ class FrameworkPaths:
     SPEC_MAPPING_SCHEMA_PATH: str = "./lakeflow_framework/schemas/spec_mapping.json"
     MAIN_SPEC_SCHEMA_PATH: str = "./lakeflow_framework/schemas/main.json"
     FLOW_GROUP_SPEC_SCHEMA_PATH: str = "./lakeflow_framework/schemas/flow_group.json"
+    NODESPEC_SPEC_SCHEMA_PATH: str = "./lakeflow_framework/schemas/spec_nodespec.json"
     EXPECTATIONS_SPEC_SCHEMA_PATH: str = "./lakeflow_framework/schemas/expectations.json"
     SECRETS_SCHEMA_PATH: str = "./lakeflow_framework/schemas/secrets.json"
     TEMPLATE_DEFINITION_SPEC_SCHEMA_PATH: str = "./lakeflow_framework/schemas/spec_template_definition.json"

--- a/src/lakeflow_framework/dataflow_spec_builder/dataflow_spec_builder.py
+++ b/src/lakeflow_framework/dataflow_spec_builder/dataflow_spec_builder.py
@@ -38,6 +38,7 @@ class DataflowSpecBuilder:
         filter_list_files (List[str]): List of files to filter.
         main_validator: Main JSON validator.
         flow_validator: Flow JSON validator.
+        nodespec_validator: Nodespec JSON validator.
         dataflow_spec_version (str): Path to the dataflow spec mapping file.
         dataflow_spec_list (List): List of dataflow specifications.
         validation_errors (Dict): Dictionary of validation errors.
@@ -139,6 +140,8 @@ class DataflowSpecBuilder:
             os.path.join(self.framework_path,FrameworkPaths.MAIN_SPEC_SCHEMA_PATH))
         self.flow_validator = utility.JSONValidator(
             os.path.join(self.framework_path,FrameworkPaths.FLOW_GROUP_SPEC_SCHEMA_PATH))
+        self.nodespec_validator = utility.JSONValidator(
+            os.path.join(self.framework_path,FrameworkPaths.NODESPEC_SPEC_SCHEMA_PATH))
 
         # Initialize storage
         self.processed_specs: List[DataflowSpec] = []
@@ -453,24 +456,19 @@ class DataflowSpecBuilder:
             # Nodespec specs use their own schema directly — the main.json
             # if/else chain doesn't route cleanly for non-standard types.
             if spec_type == "nodespec":
-                nodespec_schema_path = os.path.join(self.framework_path, "schemas", "spec_nodespec.json")
-                if os.path.exists(nodespec_schema_path):
-                    nodespec_validator = utility.JSONValidator(nodespec_schema_path)
-                    # Nodespec field names are snake_case. The metadata keys were
-                    # normalised to camelCase at read time for uniform downstream
-                    # processing, so present them as snake_case for validation.
-                    camel_to_snake = {
-                        self.Keys.DATA_FLOW_ID: "data_flow_id",
-                        self.Keys.DATA_FLOW_GROUP: "data_flow_group",
-                        self.Keys.DATA_FLOW_TYPE: "data_flow_type",
-                        self.Keys.DATA_FLOW_VERSION: "data_flow_version",
-                    }
-                    validation_data = {
-                        camel_to_snake.get(k, k): v for k, v in json_data.items()
-                    }
-                    errors = nodespec_validator.validate(validation_data)
-                else:
-                    errors = []
+                # Nodespec field names are snake_case. The metadata keys were
+                # normalised to camelCase at read time for uniform downstream
+                # processing, so present them as snake_case for validation.
+                camel_to_snake = {
+                    self.Keys.DATA_FLOW_ID: "data_flow_id",
+                    self.Keys.DATA_FLOW_GROUP: "data_flow_group",
+                    self.Keys.DATA_FLOW_TYPE: "data_flow_type",
+                    self.Keys.DATA_FLOW_VERSION: "data_flow_version",
+                }
+                validation_data = {
+                    camel_to_snake.get(k, k): v for k, v in json_data.items()
+                }
+                errors = self.nodespec_validator.validate(validation_data)
             elif file_type == "main":
                 errors = self.main_validator.validate(json_data)
             else:

--- a/src/lakeflow_framework/schemas/spec_nodespec.json
+++ b/src/lakeflow_framework/schemas/spec_nodespec.json
@@ -4,6 +4,7 @@
     "title": "Nodespec Dataflow Specification",
     "description": "Node-based dataflow spec (snake_case). A node's `config` is discriminated by node_type + source_type/target_type/table_type so editors offer only the fields valid for that node. Feature bundles (cdc, snapshot, data_quality, migration) are single nested objects; quarantine nests under data_quality. Targets declare their inputs via `sources`. Sink targets keep their current flat form for now (sink redesign deferred).",
     "$comment": "A node's `config` is discriminated at the node level via allOf/if-then keyed on node_type + source_type/target_type/table_type; each `then` selects one closed config $def, so editors offer only the fields valid for that node. Nested blobs are typed objects with descriptions. Sink targets keep their current flat form (sink_type/sink_config/sink_options) pending the sink redesign. Legacy definitions_sources.json / definitions_targets.json are camelCase; nodespec is snake_case, so source/target detail shapes are re-declared here. Literal Spark option keys (cloudFiles.*, kafka.*) are preserved verbatim.",
+    "$ref": "#/$defs/nodespec_spec",
     "$defs": {
         "nodespec_spec": {
             "type": "object",

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -17,6 +17,7 @@ class TestFrameworkPaths:
     def test_schema_paths_are_under_schemas_directory(self):
         assert FrameworkPaths.MAIN_SPEC_SCHEMA_PATH.endswith("main.json")
         assert FrameworkPaths.TEMPLATE_SPEC_SCHEMA_PATH.endswith("spec_template.json")
+        assert FrameworkPaths.NODESPEC_SPEC_SCHEMA_PATH == "./lakeflow_framework/schemas/spec_nodespec.json"
 
 
 class TestPipelineBundlePaths:

--- a/tests/unit/test_dataflow_spec_builder.py
+++ b/tests/unit/test_dataflow_spec_builder.py
@@ -227,3 +227,68 @@ class TestDataflowSpecBuilderFilters:
         }
         with pytest.raises(ValueError, match="Invalid dataflow spec files found"):
             builder._validate_dataflow_specs(bad_specs)
+
+    def test_nodespec_validator_resolves_packaged_schema(
+        self, secrets_manager, framework_src_path, minimal_bundle_tree, pipeline_context
+    ):
+        # Regression for #135: the schema lives under lakeflow_framework/schemas/,
+        # not <framework_path>/schemas/, and must be resolved eagerly (no silent skip).
+        builder = _make_builder(secrets_manager, framework_src_path, minimal_bundle_tree)
+        assert builder.nodespec_validator.schema["title"] == "Nodespec Dataflow Specification"
+
+    def test_validate_dataflow_specs_validates_nodespec_against_schema(
+        self, secrets_manager, framework_src_path, minimal_bundle_tree, pipeline_context
+    ):
+        builder = _make_builder(
+            secrets_manager,
+            framework_src_path,
+            minimal_bundle_tree,
+            ignore_validation_errors=False,
+        )
+        # Metadata keys are camelCase after read-time normalisation; `nodes` is
+        # required by spec_nodespec.json, so this payload must be rejected.
+        bad_specs = {
+            "/bad_nodespec.json": {
+                "fileType": "main",
+                "dataFlowType": "nodespec",
+                "data": {"dataFlowId": "x", "dataFlowGroup": "g", "dataFlowType": "nodespec"},
+            }
+        }
+        with pytest.raises(ValueError, match="Invalid dataflow spec files found"):
+            builder._validate_dataflow_specs(bad_specs)
+
+    def test_validate_dataflow_specs_accepts_valid_nodespec(
+        self, secrets_manager, framework_src_path, minimal_bundle_tree, pipeline_context
+    ):
+        builder = _make_builder(
+            secrets_manager,
+            framework_src_path,
+            minimal_bundle_tree,
+            ignore_validation_errors=False,
+        )
+        good_specs = {
+            "/good_nodespec.json": {
+                "fileType": "main",
+                "dataFlowType": "nodespec",
+                "data": {
+                    "dataFlowId": "x",
+                    "dataFlowGroup": "g",
+                    "dataFlowType": "nodespec",
+                    "nodes": [
+                        {
+                            "name": "src",
+                            "node_type": "source",
+                            "source_type": "delta",
+                            "config": {"table": "cat.sch.tbl"},
+                        },
+                        {
+                            "name": "tgt",
+                            "node_type": "target",
+                            "config": {"table": "tgt_tbl", "sources": ["src"]},
+                        },
+                    ],
+                },
+            }
+        }
+        builder._validate_dataflow_specs(good_specs)
+        assert builder.validation_errors == {}


### PR DESCRIPTION
## Summary
- `DataflowSpecBuilder._validate_dataflow_specs` looked for `<framework_path>/schemas/spec_nodespec.json`; since v0.20.0 the schemas live under `lakeflow_framework/schemas/`, so with the standard flat deploy (`framework.sourcePath = .../files/src`) the path never existed and the code silently took the `else: errors = []` branch (fixes #135)
- Add `FrameworkPaths.NODESPEC_SPEC_SCHEMA_PATH` and initialise `self.nodespec_validator` alongside the main/flow validators, so a missing schema fails fast at builder init instead of being skipped
- Remove the `os.path.exists()` silent-skip branch
- While verifying: `spec_nodespec.json` only declared `$defs` with no root `$ref`, so even at the correct path `Draft7Validator` accepted any payload. Added `"$ref": "#/$defs/nodespec_spec"` at the root. All 62 nodespec specs in `samples/`, `tests/` and `fixtures/` still validate cleanly against the rooted schema
- Docs: `nodespec.rst` now cites `src/lakeflow_framework/schemas/spec_nodespec.json`

## Test plan
- [x] New unit tests: constant path, validator resolves packaged schema, nodespec missing `nodes` is rejected, valid two-node nodespec is accepted
- [x] `pytest tests/unit` (373 passed)
- [x] `pytest tests -m "not spark"` (386 passed)
- [x] Script-validated every nodespec spec in the repo against the rooted schema: 62 checked, 0 failures

Note: no VERSION bump included, since this is one of four independent fix PRs opened together (#135-#138) and they would conflict on that file; happy to add one if you prefer.