### PR TITLE
fix: build table_import SCD2 except_column_list as an ordered union

### DIFF
--- a/src/lakeflow_framework/dataflow/table_import.py
+++ b/src/lakeflow_framework/dataflow/table_import.py
@@ -76,8 +76,11 @@ def create_table_import_flow(
                 sequence_by=SystemColumns.SCD2Columns.SCD2_START_AT.value,
                 apply_as_deletes=f"{is_deleted_column} = true",
                 ignore_null_updates=cdc_settings.ignore_null_updates,
-                except_column_list= (
-                    list(set(cdc_settings.except_column_list.copy().extend(*exclude_columns)))
+                # Union of the spec's except_column_list and the framework's
+                # internal columns; dict.fromkeys de-duplicates while keeping order
+                # (list.extend() returns None, so it cannot be chained here).
+                except_column_list=(
+                    list(dict.fromkeys([*cdc_settings.except_column_list, *exclude_columns]))
                     if cdc_settings.except_column_list
                     else [is_deleted_column, *scd2_columns]
                 )

--- a/tests/unit/dataflow/test_table_import.py
+++ b/tests/unit/dataflow/test_table_import.py
@@ -1,0 +1,73 @@
+"""Unit tests for dataflow/table_import.py - CDC settings assembly."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lakeflow_framework.constants import SystemColumns
+from lakeflow_framework.dataflow import table_import
+from lakeflow_framework.dataflow.cdc import CDCSettings
+
+
+class _FakeCDCFlow:
+    """Capture the CDCSettings handed to CDCFlow instead of registering a flow."""
+
+    captured: list = []
+
+    def __init__(self, settings):
+        self.settings = settings
+        _FakeCDCFlow.captured.append(settings)
+
+    def create(self, **kwargs):
+        return None
+
+
+@pytest.fixture
+def patched_table_import(monkeypatch):
+    _FakeCDCFlow.captured.clear()
+    monkeypatch.setattr(table_import.pipeline_config, "get_spark", lambda: SimpleNamespace())
+    monkeypatch.setattr(table_import.pipeline_config, "get_logger", lambda: SimpleNamespace(
+        info=lambda *a, **k: None, debug=lambda *a, **k: None
+    ))
+    monkeypatch.setattr(
+        table_import.SourceFactory, "create",
+        staticmethod(lambda _type, details: SimpleNamespace(table=details["table"])),
+    )
+    monkeypatch.setattr(table_import.View, "create_view", lambda self, **kwargs: None)
+    monkeypatch.setattr(table_import, "dp", SimpleNamespace(
+        view=lambda **kwargs: (lambda fn: fn),
+        append_flow=lambda **kwargs: (lambda fn: fn),
+    ))
+    monkeypatch.setattr(table_import, "CDCFlow", _FakeCDCFlow)
+    return _FakeCDCFlow
+
+
+def _run(cdc_settings):
+    table_import.create_table_import_flow(
+        source_details={"table": "src_tbl", "database": "db"},
+        target_table_name="tgt",
+        cdc_settings=cdc_settings,
+    )
+
+
+class TestSCD2ExceptColumnList:
+    def test_spec_except_columns_are_unioned_with_internal_columns(self, patched_table_import):
+        # Regression for #137: previously list.extend() (returns None) was fed to
+        # list(set(...)) and raised TypeError whenever except_column_list was set.
+        _run(CDCSettings(scd_type="2", keys=["id"], sequence_by="ts",
+                         except_column_list=["op", "is_deleted"]))
+
+        settings = patched_table_import.captured[0]
+        scd2_columns = [c.value for c in SystemColumns.SCD2Columns]
+        expected = ["op", "is_deleted", "WATERMARK_COLUMN", *scd2_columns]
+        assert settings.except_column_list == expected  # order preserved, no duplicates
+        assert len(settings.except_column_list) == len(set(settings.except_column_list))
+
+    def test_default_except_columns_when_spec_omits_them(self, patched_table_import):
+        _run(CDCSettings(scd_type="2", keys=["id"], sequence_by="ts"))
+
+        settings = patched_table_import.captured[0]
+        scd2_columns = [c.value for c in SystemColumns.SCD2Columns]
+        assert settings.except_column_list == ["is_deleted", *scd2_columns]


### PR DESCRIPTION
## Summary
- `create_table_import_flow` built the SCD2 `except_column_list` as `list(set(cdc_settings.except_column_list.copy().extend(*exclude_columns)))`. `list.extend()` returns `None` and takes a single iterable, so any spec that supplied `except_column_list` raised `TypeError` (`list.extend() takes exactly one argument (4 given)`, and would have been `'NoneType' object is not iterable` after that) (fixes #137)
- Replace with `list(dict.fromkeys([*cdc_settings.except_column_list, *exclude_columns]))`: a de-duplicated union that also preserves order (unlike `list(set(...))`), so the resulting column list is deterministic
- Add `tests/unit/dataflow/test_table_import.py`, which drives `create_table_import_flow` with patched `dp`/`View`/`SourceFactory`/`CDCFlow` and asserts the `CDCSettings` handed to `CDCFlow` for both the spec-supplied and default cases

## Test plan
- [x] New test fails on `main` with the `TypeError` above and passes with the fix
- [x] `pytest tests/unit` (372 passed)

Note: no VERSION bump included, since this is one of four independent fix PRs opened together (#135-#138) and they would conflict on that file; happy to add one if you prefer.