### PR TITLE
fix: make workspace.host an optional pipeline configuration

### DIFF
--- a/src/lakeflow_framework/dlt_pipeline_builder.py
+++ b/src/lakeflow_framework/dlt_pipeline_builder.py
@@ -45,7 +45,8 @@ class DLTPipelineBuilder:
         framework_path (str): The path to the framework to use for the pipeline.
         bundle_path (str): The path to the bundle to use for the pipeline.
         dataflow_path (str): The path to the dataflow to use for the pipeline.
-        workspace_host (str): The host to use for the pipeline.
+        workspace_host (str): The workspace host, from the optional ``workspace.host`` pipeline
+            configuration or ``spark.databricks.workspaceUrl`` when unset.
         
         dataflow_specs (List[DataflowSpec]): The dataflow specifications to use for the pipeline.
         dataflow_spec_filters (Dict[str, Any]): The filters to use for the dataflow specifications.
@@ -62,8 +63,10 @@ class DLTPipelineBuilder:
     MANDATORY_CONFIG_PARAMS = [
         DLTPipelineSettingKeys.BUNDLE_SOURCE_PATH,
         DLTPipelineSettingKeys.FRAMEWORK_SOURCE_PATH,
-        DLTPipelineSettingKeys.WORKSPACE_HOST
     ]
+
+    # Spark conf key Databricks sets on every cluster with the workspace URL (no scheme).
+    SPARK_WORKSPACE_URL_CONF = "spark.databricks.workspaceUrl"
 
     def __init__(self, spark: SparkSession, dbutils: DBUtils):
         """Initialize the pipeline builder with Spark session and utilities."""
@@ -126,7 +129,13 @@ class DLTPipelineBuilder:
         self.bundle_path = config_values[DLTPipelineSettingKeys.BUNDLE_SOURCE_PATH]
         self.framework_path = config_values[DLTPipelineSettingKeys.FRAMEWORK_SOURCE_PATH]
         self._framework_config_path = resolve_framework_config_path(self.framework_path)
-        self.workspace_host = config_values[DLTPipelineSettingKeys.WORKSPACE_HOST]
+        # workspace.host is optional: a DAB target that follows the CLI profile
+        # resolves ${workspace.host} to "" at deploy time, so fall back to the
+        # workspace URL Databricks exposes on the cluster instead of failing.
+        self.workspace_host = (
+            self.spark.conf.get(DLTPipelineSettingKeys.WORKSPACE_HOST, None)
+            or self.spark.conf.get(self.SPARK_WORKSPACE_URL_CONF, None)
+        )
 
     def _init_configurations(self) -> None:
         """Load and validate all necessary configurations."""

--- a/tests/unit/test_dlt_pipeline_builder.py
+++ b/tests/unit/test_dlt_pipeline_builder.py
@@ -1,0 +1,67 @@
+"""Unit tests for dlt_pipeline_builder.py - mandatory / optional pipeline configuration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lakeflow_framework.constants import DLTPipelineSettingKeys
+from lakeflow_framework.dlt_pipeline_builder import DLTPipelineBuilder
+
+
+class _FakeConf:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+def _builder_with_conf(conf_values):
+    """Bare instance (no __init__) so only _load_mandatory_paths is exercised."""
+    builder = DLTPipelineBuilder.__new__(DLTPipelineBuilder)
+    builder.spark = SimpleNamespace(conf=_FakeConf(conf_values))
+    return builder
+
+
+def _base_conf(framework_src_path):
+    return {
+        DLTPipelineSettingKeys.BUNDLE_SOURCE_PATH: "/Workspace/bundle/src",
+        DLTPipelineSettingKeys.FRAMEWORK_SOURCE_PATH: str(framework_src_path),
+    }
+
+
+class TestLoadMandatoryPaths:
+    def test_workspace_host_is_not_mandatory(self):
+        # Regression for #138: a DAB target that follows the CLI profile resolves
+        # ${workspace.host} to "" and every pipeline failed at startup.
+        assert DLTPipelineSettingKeys.WORKSPACE_HOST not in DLTPipelineBuilder.MANDATORY_CONFIG_PARAMS
+
+    def test_missing_source_paths_still_raise(self, framework_src_path):
+        builder = _builder_with_conf({})
+        with pytest.raises(ValueError, match="Missing mandatory config parameters"):
+            builder._load_mandatory_paths()
+
+    def test_workspace_host_from_pipeline_configuration(self, framework_src_path):
+        conf = {**_base_conf(framework_src_path), DLTPipelineSettingKeys.WORKSPACE_HOST: "https://adb-1.azuredatabricks.net"}
+        builder = _builder_with_conf(conf)
+        builder._load_mandatory_paths()
+        assert builder.workspace_host == "https://adb-1.azuredatabricks.net"
+        assert builder.bundle_path == "/Workspace/bundle/src"
+        assert builder.framework_path == str(framework_src_path)
+
+    def test_workspace_host_falls_back_to_spark_workspace_url(self, framework_src_path):
+        conf = {
+            **_base_conf(framework_src_path),
+            DLTPipelineSettingKeys.WORKSPACE_HOST: "",  # what an unpinned ${workspace.host} resolves to
+            DLTPipelineBuilder.SPARK_WORKSPACE_URL_CONF: "adb-1.azuredatabricks.net",
+        }
+        builder = _builder_with_conf(conf)
+        builder._load_mandatory_paths()
+        assert builder.workspace_host == "adb-1.azuredatabricks.net"
+
+    def test_workspace_host_none_when_neither_available(self, framework_src_path):
+        builder = _builder_with_conf(_base_conf(framework_src_path))
+        builder._load_mandatory_paths()
+        assert builder.workspace_host is None


### PR DESCRIPTION
## Summary
- `DLTPipelineBuilder.MANDATORY_CONFIG_PARAMS` required the `workspace.host` pipeline configuration, but the value was only stored on `self.workspace_host` and never read anywhere. In a DAB target that does not pin `workspace.host` (a personal dev target following the CLI profile, as the deploy docs recommend), `${workspace.host}` resolves to `""` and every pipeline failed at startup with `Missing mandatory config parameters: ['workspace.host']` (fixes #138)
- Remove `workspace.host` from `MANDATORY_CONFIG_PARAMS`; `bundle.sourcePath` and `framework.sourcePath` remain mandatory
- Read `workspace.host` optionally and fall back to `spark.databricks.workspaceUrl` (which Databricks sets on every cluster), so `self.workspace_host` is still populated for anything that wants it. Kept the attribute rather than deleting it to stay backward compatible for downstream code
- Sample/template `databricks.yml` files still pass `workspace.host: ${var.workspace_host}`; that keeps working and is now simply optional
- Add `tests/unit/test_dlt_pipeline_builder.py` covering the mandatory list, explicit host, empty-string fallback to the Spark conf, and the neither-set case

## Test plan
- [x] `pytest tests/unit/test_dlt_pipeline_builder.py` (5 passed)
- [x] `pytest tests/unit` (375 passed)

Note: no VERSION bump included, since this is one of four independent fix PRs opened together (#135-#138) and they would conflict on that file; happy to add one if you prefer.